### PR TITLE
MQ data directory changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,11 @@ LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.vcs-url="https://github.com/EGA-archive/LocalEGA-mq"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 
-RUN mkdir -p /ega && \
-    chown 100:101 /ega
+ENV RABBITMQ_CONFIG_FILE=/var/lib/rabbitmq/rabbitmq
+ENV RABBITMQ_ADVANCED_CONFIG_FILE=/var/lib/rabbitmq/advanced
+ENV RABBITMQ_LOG_BASE=/var/lib/rabbitmq
 
-VOLUME /ega
-
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates openssl
 
 RUN rabbitmq-plugins enable --offline rabbitmq_federation rabbitmq_federation_management rabbitmq_shovel rabbitmq_shovel_management
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.vcs-url="https://github.com/EGA-archive/LocalEGA-mq"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 
-VOLUME /var/lib/rabbitmq
+RUN mkdir -p /ega && \
+    chown 100:101 /ega
+
+VOLUME /ega
 
 RUN apk add --no-cache ca-certificates
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ The following environment variables can be used to configure the broker:
 
 | Variable | Description |
 |---------:|:------------|
+| `MQDATA` | Default data directory for RabbitMQ configuration |
+| `RABBITMQ_CONFIG_FILE` | Default rabbitmq.conf directory path |
+| `RABBITMQ_ADVANCED_CONFIG_FILE` | Default advanced.config directory path |
+| `RABBITMQ_LOG_BASE` | Default logs directory path |
+| `RABBITMQ_MNESIA_BASE` | Default data directory path for RabbitMQ |
 | `MQ_VHOST` | Default vhost other than `/` |
 | `MQ_VERIFY` | Set to `verify_none` to disable verification of client certificate |
 | `MQ_USER` | Default user (with admin rights) |

--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ The following environment variables can be used to configure the broker:
 
 | Variable | Description |
 |---------:|:------------|
-| `MQDATA` | Default data directory for RabbitMQ configuration |
-| `RABBITMQ_CONFIG_FILE` | Default rabbitmq.conf directory path |
-| `RABBITMQ_ADVANCED_CONFIG_FILE` | Default advanced.config directory path |
-| `RABBITMQ_LOG_BASE` | Default logs directory path |
-| `RABBITMQ_MNESIA_BASE` | Default data directory path for RabbitMQ |
 | `MQ_VHOST` | Default vhost other than `/` |
 | `MQ_VERIFY` | Set to `verify_none` to disable verification of client certificate |
 | `MQ_USER` | Default user (with admin rights) |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@
 [[ -z "${CEGA_CONNECTION}" ]] && echo 'Environment variable CEGA_CONNECTION is empty' 1>&2 && exit 1
 
 
-cat >> /etc/rabbitmq/rabbitmq.conf <<EOF
+cat >> "${MQDATA}/rabbitmq.conf" <<EOF
 listeners.ssl.default = 5671
 ssl_options.cacertfile = ${MQ_CA:-/etc/rabbitmq/ssl/ca.pem}
 ssl_options.certfile = ${MQ_SERVER_CERT:-/etc/rabbitmq/ssl/mq-server.pem}
@@ -15,13 +15,13 @@ ssl_options.fail_if_no_peer_cert = true
 ssl_options.versions.1 = tlsv1.2
 disk_free_limit.absolute = 1GB
 management.listener.port = 15672
-management.load_definitions = /etc/rabbitmq/definitions.json
+management.load_definitions = ${MQDATA}/definitions.json
 default_vhost = ${MQ_VHOST:-/}
 EOF
 
-chmod 600 /etc/rabbitmq/rabbitmq.conf
+chmod 600 "${MQDATA}/rabbitmq.conf"
 
-cat > /etc/rabbitmq/definitions.json <<EOF
+cat > "${MQDATA}/definitions.json" <<EOF
 {
   "users": [
     {
@@ -69,9 +69,9 @@ cat > /etc/rabbitmq/definitions.json <<EOF
   ]
 }
 EOF
-chmod 600 /etc/rabbitmq/definitions.json
+chmod 600 "${MQDATA}/definitions.json"
 
-cat > /etc/rabbitmq/advanced.config <<EOF
+cat > "${MQDATA}/advanced.config" <<EOF
 [
   {rabbit,
     [{tcp_listeners, []}
@@ -131,7 +131,7 @@ cat > /etc/rabbitmq/advanced.config <<EOF
     ]}
 ].
 EOF
-chmod 600 /etc/rabbitmq/advanced.config
+chmod 600 "${MQDATA}/advanced.config"
 
 
 # Ownership by 'rabbitmq'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@
 [ -z "${MQ_PASSWORD_HASH}" ] && echo 'Environment variable MQ_PASSWORD_HASH is empty' 1>&2 && exit 1
 [ -z "${CEGA_CONNECTION}" ] && echo 'Environment variable CEGA_CONNECTION is empty' 1>&2 && exit 1
 
-if [ ! -e "${MQ_SERVER_CERT}" ] || [ ! -e "${MQ_SERVER_KEY}" ]; then
+if [ -z "${MQ_SERVER_CERT}" ] || [ -z "${MQ_SERVER_KEY}" ]; then
 SSL_SUBJ="/C=SE/ST=Sweden/L=Uppsala/O=NBIS/OU=SysDevs/CN=LocalEGA"
 mkdir -p "${HOME}/ssl"
 # Generating the SSL certificate + key

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@
 [ -z "${MQ_PASSWORD_HASH}" ] && echo 'Environment variable MQ_PASSWORD_HASH is empty' 1>&2 && exit 1
 [ -z "${CEGA_CONNECTION}" ] && echo 'Environment variable CEGA_CONNECTION is empty' 1>&2 && exit 1
 
-if [ ! -e "${PG_SERVER_CERT}" ] || [ ! -e "${PG_SERVER_KEY}" ]; then
+if [ ! -e "${MQ_SERVER_CERT}" ] || [ ! -e "${MQ_SERVER_KEY}" ]; then
 SSL_SUBJ="/C=SE/ST=Sweden/L=Uppsala/O=NBIS/OU=SysDevs/CN=LocalEGA"
 mkdir -p "${HOME}/ssl"
 # Generating the SSL certificate + key


### PR DESCRIPTION
chante the configurations default directory

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Solving issues like:
```
/usr/local/bin/ega-entrypoint.sh: line 8: /etc/rabbitmq/rabbitmq.conf: Read-only file system
chmod: /etc/rabbitmq/rabbitmq.conf: No such file or directory
/usr/local/bin/ega-entrypoint.sh: line 24: /etc/rabbitmq/definitions.json: Read-only file system
chmod: /etc/rabbitmq/definitions.json: No such file or directory
/usr/local/bin/ega-entrypoint.sh: line 74: /etc/rabbitmq/advanced.config: Read-only file system
chmod: /etc/rabbitmq/advanced.config: No such file or directory
```

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. change config directory path
2. making it more configurable by adding `MQDATA`


### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
