### PR TITLE
New config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG SOURCE_COMMIT
 LABEL maintainer "EGA System Developers"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
-LABEL org.label-schema.vcs-url="https://github.com/EGA-archive/LocalEGA-mq"
+LABEL org.label-schema.vcs-url="https://github.com/neicnordic/LocalEGA-mq"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 
 ENV RABBITMQ_CONFIG_FILE=/var/lib/rabbitmq/rabbitmq

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -124,7 +124,7 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
       "arguments": {}
     },
     {
-      "name": "stableIDs",
+      "name": "accessionIDs",
       "vhost": "${MQ_VHOST:-/}",
       "durable": true,
       "auto_delete": false,
@@ -347,7 +347,7 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
       "arguments": {}
     },
     {
-      "name": "stableIDs",
+      "name": "accessionIDs",
       "vhost": "${MQ_VHOST:-/}",
       "durable": true,
       "auto_delete": false,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,17 +57,6 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
   ],
   "parameters": [
     {
-      "name": "CEGA-ids",
-      "vhost": "${MQ_VHOST:-/}",
-      "component": "federation-upstream",
-      "value": {
-        "ack-mode": "on-confirm",
-        "queue": "v1.stableIDs",
-        "trust-user-id": false,
-        "uri": "${CEGA_CONNECTION}"
-      }
-    },
-    {
       "name": "CEGA-files",
       "vhost": "${MQ_VHOST:-/}",
       "component": "federation-upstream",
@@ -89,21 +78,18 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
       "definition": {
         "federation-upstream": "CEGA-files"
       }
-    },
-    {
-      "vhost": "${MQ_VHOST:-/}",
-      "name": "CEGA-ids",
-      "pattern": "stableIDs",
-      "apply-to": "queues",
-      "priority": 0,
-      "definition": {
-        "federation-upstream": "CEGA-ids"
-      }
     }
   ],
   "queues": [
-    {
-      "name": "stableIDs",
+        {
+      "name": "archived",
+      "vhost": "${MQ_VHOST:-/}",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+        {
+      "name": "completed",
       "vhost": "${MQ_VHOST:-/}",
       "durable": true,
       "auto_delete": false,
@@ -117,7 +103,35 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
       "arguments": {}
     },
     {
-      "name": "archived",
+      "name": "inbox",
+      "vhost": "${MQ_VHOST:-/}",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
+      "name": "ingest",
+      "vhost": "${MQ_VHOST:-/}",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
+      "name": "mappings",
+      "vhost": "${MQ_VHOST:-/}",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
+      "name": "stableIDs",
+      "vhost": "${MQ_VHOST:-/}",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
+      "name": "verified",
       "vhost": "${MQ_VHOST:-/}",
       "durable": true,
       "auto_delete": false,
@@ -126,7 +140,7 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
   ],
   "exchanges": [
     {
-      "name": "cega",
+      "name": "to_cega",
       "vhost": "${MQ_VHOST:-/}",
       "type": "topic",
       "durable": true,
@@ -135,22 +149,12 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
       "arguments": {}
     },
     {
-      "name": "lega",
+      "name": "sda",
       "vhost": "${MQ_VHOST:-/}",
       "type": "topic",
       "durable": true,
       "auto_delete": false,
       "internal": false,
-      "arguments": {}
-    }
-  ],
-  "bindings": [
-    {
-      "source": "lega",
-      "vhost": "${MQ_VHOST:-/}",
-      "destination": "archived",
-      "destination_type": "queue",
-      "routing_key": "archived",
       "arguments": {}
     }
   ]
@@ -162,95 +166,120 @@ MQ_VHOST="/${MQ_VHOST}"
 fi
 cat > "/var/lib/rabbitmq/advanced.config" <<EOF
 [
-  {rabbit,
-    [{tcp_listeners, []}
+  {rabbit,  [
+    {tcp_listeners, []}
   ]},
-  {rabbitmq_shovel,
-    [{shovels, [
-      {to_cega,
-        [{source,
-          [{protocol, amqp091},
-            {uris, ["amqp://${MQ_VHOST:-}"]},
-            {declarations, [{'queue.declare', [{exclusive, true}]},
-              {'queue.bind',
-                [{exchange, <<"cega">>},
-                  {queue, <<>>},
-                  {routing_key, <<"#">>}
-                ]}
-            ]},
-            {queue, <<>>},
-            {prefetch_count, 10}
-          ]},
-          {destination,
-            [{protocol, amqp091},
-              {uris, ["${CEGA_CONNECTION}"]},
-              {declarations, []},
-              {publish_properties, [{delivery_mode, 2}]},
-              {publish_fields, [{exchange, <<"localega.v1">>}]}]},
-          {ack_mode, on_confirm},
-          {reconnect_delay, 5}
+  {rabbitmq_shovel, [
+    {shovels, [
+      {to_cega, [
+        {source, [
+          {protocol, amqp091},
+          {uris,[ "amqp://${MQ_VHOST:-}" ]},
+          {declarations,  [
+                            {'queue.declare', [{exclusive, true}]},
+                            {'queue.bind', [{exchange, <<"to_cega">>}, {queue, <<>>}, {routing_key, <<"#">>}]}
+                          ]},
+          {queue, <<>>},
+          {prefetch_count, 10}
         ]},
-      {cega_completion,
-        [{source,
-          [{protocol, amqp091},
-            {uris, ["amqp://${MQ_VHOST:-}"]},
-            {declarations, [{'queue.declare', [{exclusive, true}]},
-              {'queue.bind',
-                [{exchange, <<"lega">>},
-                  {queue, <<>>},
-                  {routing_key, <<"completed">>}
-                ]}
-            ]},
-            {queue, <<>>},
-            {prefetch_count, 10}
-          ]},
-          {destination,
-            [{protocol, amqp091},
-              {uris, ["amqp://${MQ_VHOST:-}"]},
-              {declarations, []},
-              {publish_properties, [{delivery_mode, 2}]},
-              {publish_fields, [{exchange, <<"cega">>},
-                {routing_key, <<"files.completed">>}
-              ]}
-            ]},
-          {ack_mode, on_confirm},
-          {reconnect_delay, 5}
-        ]},
-      {cega_verification,
-        [{source,
-          [{protocol, amqp091},
-            {uris, ["amqp://${MQ_VHOST:-}"]},
-            {declarations, [{'queue.declare', [{exclusive, true}]},
-              {'queue.bind',
-                [{exchange, <<"lega">>},
-                  {queue, <<>>},
-                  {routing_key, <<"verified">>}
-                ]}
-            ]},
-            {queue, <<>>},
-            {prefetch_count, 10}
-          ]},
-          {destination,
-            [{protocol, amqp091},
-              {uris, ["amqp://${MQ_VHOST:-}"]},
-              {declarations, []},
-              {publish_properties, [{delivery_mode, 2}]},
-              {publish_fields, [{exchange, <<"cega">>},
-                {routing_key, <<"files.verified">>}
-              ]}
-            ]},
-          {ack_mode, on_confirm},
-          {reconnect_delay, 5}
+        {destination, [
+                        {protocol, amqp091},
+                        {uris, ["${CEGA_CONNECTION}"]},
+                        {declarations, []},
+                        {publish_properties, [{delivery_mode, 2}]},
+                        {publish_fields, [{exchange, <<"localega.v1">>}]}
+                      ]},
+        {ack_mode, on_confirm},
+        {reconnect_delay, 5}
+      ]},
+      {cega_completion, [
+        {source,  [
+                    {protocol, amqp091},
+                    {uris, ["amqp://${MQ_VHOST:-}"]},
+                    {declarations, [{'queue.declare', [{exclusive, true}] }, {'queue.bind', [{exchange, <<"sda">>}, {queue, <<>>}, {routing_key, <<"completed">>}] } ] },
+                    {queue, <<>>},
+                    {prefetch_count, 10}
+                  ]},
+        {destination, [
+                        {protocol, amqp091},
+                        {uris, ["amqp://${MQ_VHOST:-}"]},
+                        {declarations, []},
+                        {publish_properties, [{delivery_mode, 2}]},
+                        {publish_fields, [{exchange, <<"to_cega">>},
+                        {routing_key, <<"files.completed">>}
+                      ]},
+        {ack_mode, on_confirm},
+        {reconnect_delay, 5}
         ]}
+      ]},
+      {cega_error, [
+        {source,  [
+                    {protocol, amqp091},
+                    {uris, ["amqp://${MQ_VHOST:-}"]},
+                    {declarations, [{'queue.declare', [{exclusive, true}] }, {'queue.bind', [{exchange, <<"sda">>}, {queue, <<>>}, {routing_key, <<"error">>}] } ] },
+                    {queue, <<>>},
+                    {prefetch_count, 10}
+                  ]},
+        {destination, [
+                        {protocol, amqp091},
+                        {uris, ["amqp://${MQ_VHOST:-}"]},
+                        {declarations, []},
+                        {publish_properties, [{delivery_mode, 2}]},
+                        {publish_fields, [{exchange, <<"to_cega">>},
+                        {routing_key, <<"files.error">>}
+                      ]},
+        {ack_mode, on_confirm},
+        {reconnect_delay, 5}
+        ]}
+      ]},
+      {cega_inbox, [
+        {source,  [
+                    {protocol, amqp091},
+                    {uris, ["amqp://${MQ_VHOST:-}"]},
+                    {declarations, [{'queue.declare', [{exclusive, true}] }, {'queue.bind', [{exchange, <<"sda">>}, {queue, <<>>}, {routing_key, <<"inbox">>}] } ] },
+                    {queue, <<>>},
+                    {prefetch_count, 10}
+                  ]},
+        {destination, [
+                        {protocol, amqp091},
+                        {uris, ["amqp://${MQ_VHOST:-}"]},
+                        {declarations, []},
+                        {publish_properties, [{delivery_mode, 2}]},
+                        {publish_fields, [{exchange, <<"to_cega">>},
+                        {routing_key, <<"files.inbox">>}
+                      ]},
+        {ack_mode, on_confirm},
+        {reconnect_delay, 5}
+        ]}
+      ]},
+      {cega_verified, [
+        {source,  [
+                    {protocol, amqp091},
+                    {uris, ["amqp://${MQ_VHOST:-}"]},
+                    {declarations, [{'queue.declare', [{exclusive, true}] }, {'queue.bind', [{exchange, <<"sda">>}, {queue, <<>>}, {routing_key, <<"verified">>}] } ] },
+                    {queue, <<>>},
+                    {prefetch_count, 10}
+                  ]},
+        {destination, [
+                        {protocol, amqp091},
+                        {uris, ["amqp://${MQ_VHOST:-}"]},
+                        {declarations, []},
+                        {publish_properties, [{delivery_mode, 2}]},
+                        {publish_fields, [{exchange, <<"to_cega">>},
+                        {routing_key, <<"files.verified">>}
+                      ]},
+        {ack_mode, on_confirm},
+        {reconnect_delay, 5}
+        ]}
+      ]}
     ]}
-    ]}
+  ]}
 ].
 EOF
 chmod 600 "/var/lib/rabbitmq/advanced.config"
 else
 cat > "/var/lib/rabbitmq/definitions.json" <<EOF
 {
-  "rabbit_version": "3.7",
   "users": [
     {
       "name": "${MQ_USER}",
@@ -273,17 +302,17 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
       "read": ".*"
     }
   ],
-  "parameters": [],
-  "global_parameters": [
-    {
-      "name": "cluster_name",
-      "value": "rabbit@localhost"
-    }
-  ],
   "policies": [],
   "queues": [
-    {
+        {
       "name": "archived",
+      "vhost": "${MQ_VHOST:-/}",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+        {
+      "name": "completed",
       "vhost": "${MQ_VHOST:-/}",
       "durable": true,
       "auto_delete": false,
@@ -297,35 +326,21 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
       "arguments": {}
     },
     {
-      "name": "files.completed",
+      "name": "inbox",
       "vhost": "${MQ_VHOST:-/}",
       "durable": true,
       "auto_delete": false,
       "arguments": {}
     },
     {
-      "name": "files.verified",
+      "name": "ingest",
       "vhost": "${MQ_VHOST:-/}",
       "durable": true,
       "auto_delete": false,
       "arguments": {}
     },
     {
-      "name": "files.error",
-      "vhost": "${MQ_VHOST:-/}",
-      "durable": true,
-      "auto_delete": false,
-      "arguments": {}
-    },
-    {
-      "name": "files.inbox",
-      "vhost": "${MQ_VHOST:-/}",
-      "durable": true,
-      "auto_delete": false,
-      "arguments": {}
-    },
-    {
-      "name": "files.processing",
+      "name": "mappings",
       "vhost": "${MQ_VHOST:-/}",
       "durable": true,
       "auto_delete": false,
@@ -338,82 +353,23 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
       "auto_delete": false,
       "arguments": {}
     },
+    {
+      "name": "verified",
+      "vhost": "${MQ_VHOST:-/}",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    }
   ],
   "exchanges": [
     {
-      "name": "lega",
+      "name": "sda",
       "vhost": "${MQ_VHOST:-/}",
       "type": "topic",
       "durable": true,
       "auto_delete": false,
       "internal": false,
       "arguments": {}
-    }
-  ],
-  "bindings": [
-    {
-      "source": "lega",
-      "vhost": "${MQ_VHOST:-/}",
-      "destination_type": "queue",
-      "arguments": {},
-      "destination": "archived",
-      "routing_key": "archived"
-    },
-    {
-      "source": "lega",
-      "vhost": "${MQ_VHOST:-/}",
-      "destination_type": "queue",
-      "arguments": {},
-      "destination": "files",
-      "routing_key": "files"
-    },
-    {
-      "source": "lega",
-      "vhost": "${MQ_VHOST:-/}",
-      "destination_type": "queue",
-      "arguments": {},
-      "destination": "files.completed",
-      "routing_key": "files.completed"
-    },
-    {
-      "source": "lega",
-      "vhost": "${MQ_VHOST:-/}",
-      "destination_type": "queue",
-      "arguments": {},
-      "destination": "files.verified",
-      "routing_key": "files.verified"
-    },
-    {
-      "source": "lega",
-      "vhost": "${MQ_VHOST:-/}",
-      "destination_type": "queue",
-      "arguments": {},
-      "destination": "files.error",
-      "routing_key": "files.error"
-    },
-    {
-      "source": "lega",
-      "vhost": "${MQ_VHOST:-/}",
-      "destination_type": "queue",
-      "arguments": {},
-      "destination": "files.inbox",
-      "routing_key": "files.inbox"
-    },
-    {
-      "source": "lega",
-      "vhost": "${MQ_VHOST:-/}",
-      "destination_type": "queue",
-      "arguments": {},
-      "destination": "files.processing",
-      "routing_key": "files.processing"
-    },
-    {
-      "source": "lega",
-      "vhost": "${MQ_VHOST:-/}",
-      "destination_type": "queue",
-      "arguments": {},
-      "destination": "stableIDs",
-      "routing_key": "stableIDs"
     }
   ]
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Reworked the queues to work with the new setup from CRG.
The setup now has 2 distinct modes, federated and standalone.

**Federated** 
Here we have 2 exchanges `sda` and `to_cega`, all messages published in the `to_cega` exchange are shoveled upstream.
The `files`queue is mirrored down from CRG and the only service interacting with that one is `intercept`.
There is a number of local shovels that moves messaged published to the `sda` exchange with the following routing keys; `inbox`, `verified`, `completed` and `error` to the `to_cega` exchange while prepending `files.` to the routing key.

**Standalone**
This one has no shovels or federation links and only one exchange `sda`. 

**Queues**
The queues are identical  in both standalone and the federated setup.
- `archived`, for when a file has been ingested
- `completed`, a completed file, ready for download
- `error`, all errors are sent here
- `files`, only used in a federated setup, messaged from CRG are coming here.
- `inbox`, for inbox operations
- `ingest`, for messages that will start an ingestion process
- `mappings`, for dataset mappings
- `accessionIDs`, for assigning accession IDs
- `verified`, when a file has been verified

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
