### PR TITLE
fix missing mappings queue and source for stand-alone

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -525,7 +525,7 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
         "routing_key": "files"
     },
     {
-        "source": "localega",
+        "source": "sda",
         "vhost": "${MQ_VHOST:-/}",
         "destination_type": "queue",
         "arguments": {},
@@ -533,7 +533,7 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
         "routing_key": "inbox"
     },
     {
-        "source": "localega",
+        "source": "sda",
         "vhost": "${MQ_VHOST:-/}",
         "destination_type": "queue",
         "arguments": {},

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -235,6 +235,14 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
         "vhost": "${MQ_VHOST:-/}",
         "destination_type": "queue",
         "arguments": {},
+        "destination": "mappings",
+        "routing_key": "mappings"
+    },
+    {
+        "source": "sda",
+        "vhost": "${MQ_VHOST:-/}",
+        "destination_type": "queue",
+        "arguments": {},
         "destination": "verified",
         "routing_key": "verified"
     }
@@ -531,6 +539,14 @@ cat > "/var/lib/rabbitmq/definitions.json" <<EOF
         "arguments": {},
         "destination": "ingest",
         "routing_key": "ingest"
+    },
+    {
+        "source": "sda",
+        "vhost": "${MQ_VHOST:-/}",
+        "destination_type": "queue",
+        "arguments": {},
+        "destination": "mappings",
+        "routing_key": "mappings"
     },
     {
         "source": "sda",


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix


### Pull request long description:
<!-- Describe your pull request in detail. -->

missing mappings queue caused mapper not to work properly
 `localega` source in stand-alone not needed

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. add mappings bindings
2. remove `localega` source from stand-alone
