### PR TITLE
move configurations to definitions.json #minor

### DIFF
--- a/.github/integration/setup/10_make_certs.sh
+++ b/.github/integration/setup/10_make_certs.sh
@@ -17,7 +17,7 @@ openssl req -config setup/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/d
 openssl x509 -req -in ./certs/db.csr -days 1200 -CA ./certs/ca.pem -CAkey ./certs/ca-key.pem -set_serial 01 -out ./certs/db.pem -extensions server_cert -extfile setup/ssl.cnf
 
 # Create client certificate
-openssl req -config setup/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/client-key.pem -out ./certs/client.csr -extensions client_cert
+openssl req -config setup/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/client-key.pem -out ./certs/client.csr -extensions client_cert -subj "/CN=lega_in/CN=admin/"
 openssl x509 -req -in ./certs/client.csr -days 1200 -CA ./certs/ca.pem -CAkey ./certs/ca-key.pem -set_serial 01 -out ./certs/client.pem -extensions client_cert -extfile setup/ssl.cnf
 
 chmod 644 certs/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ LABEL org.label-schema.vcs-url="https://github.com/neicnordic/sda-mq"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 
 ENV RABBITMQ_CONFIG_FILE=/var/lib/rabbitmq/rabbitmq
-ENV RABBITMQ_ADVANCED_CONFIG_FILE=/var/lib/rabbitmq/advanced.config
 ENV RABBITMQ_LOG_BASE=/var/lib/rabbitmq
 
 RUN apk add --no-cache ca-certificates openssl

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "${NOTLS+x}" ]; then
 		listeners.tcp.default = 5672
 		disk_free_limit.absolute = 1GB
 		management.tcp.port = 15672
-		management.load_definitions = /var/lib/rabbitmq/definitions.json
+		load_definitions = /var/lib/rabbitmq/definitions.json
 		default_vhost = ${MQ_VHOST:-/}
 	EOF
 else
@@ -27,7 +27,7 @@ else
 			management.ssl.port = 15672
 			management.ssl.certfile   = ${MQ_SERVER_CERT}
 			management.ssl.keyfile    = ${MQ_SERVER_KEY}
-			management.load_definitions = /var/lib/rabbitmq/definitions.json
+			load_definitions = /var/lib/rabbitmq/definitions.json
 			default_vhost = ${MQ_VHOST:-/}
 		EOF
 
@@ -44,6 +44,10 @@ else
 	fi
 
 	chmod 600 "/var/lib/rabbitmq/rabbitmq.conf"
+fi
+
+if [ -n "${MQ_VHOST}" ]; then
+	MQ_SHOVEL_VHOST="/${MQ_VHOST}"
 fi
 
 if [ -n "${CEGA_CONNECTION}" ]; then
@@ -73,15 +77,97 @@ if [ -n "${CEGA_CONNECTION}" ]; then
 			],
 			"parameters": [
 				{
-					"name": "CEGA-files",
-					"vhost": "${MQ_VHOST:-/}",
+					"component": "shovel",
+					"name": "to_cega",
+					"value": {
+						"ack-mode": "on-confirm",
+						"dest-add-forward-headers": true,
+						"dest-exchange": "localega.v1",
+						"dest-protocol": "amqp091",
+						"dest-uri": "${CEGA_CONNECTION}",
+						"reconnect-delay": 5,
+						"src-delete-after": "never",
+						"src-exchange": "to_cega",
+						"src-exchange-key": "#",
+						"src-protocol": "amqp091",
+						"src-uri": "amqp://${MQ_SHOVEL_VHOST:-}"
+					},
+					"vhost": "${MQ_VHOST:-/}"
+				},
+				{
+					"component": "shovel",
+					"name": "cega_inbox",
+					"value": {
+						"ack-mode": "on-confirm",
+						"dest-exchange": "to_cega",
+						"dest-exchange-key": "files.inbox",
+						"dest-protocol": "amqp091",
+						"dest-uri": "amqp://${MQ_SHOVEL_VHOST:-}",
+						"src-delete-after": "never",
+						"src-protocol": "amqp091",
+						"src-queue": "inbox",
+						"src-uri": "amqp://${MQ_SHOVEL_VHOST:-}"
+					},
+					"vhost": "${MQ_VHOST:-/}"
+				},
+				{
+					"component": "shovel",
+					"name": "cega_completion",
+					"value": {
+						"ack-mode": "on-confirm",
+						"dest-exchange": "to_cega",
+						"dest-exchange-key": "files.completed",
+						"dest-protocol": "amqp091",
+						"dest-uri": "amqp://${MQ_SHOVEL_VHOST:-}",
+						"src-delete-after": "never",
+						"src-protocol": "amqp091",
+						"src-queue": "completed",
+						"src-uri": "amqp://${MQ_SHOVEL_VHOST:-}"
+					},
+					"vhost": "${MQ_VHOST:-/}"
+				},
+				{
+					"component": "shovel",
+					"name": "cega_verified",
+					"value": {
+						"ack-mode": "on-confirm",
+						"dest-exchange": "to_cega",
+						"dest-exchange-key": "files.verified",
+						"dest-protocol": "amqp091",
+						"dest-uri": "amqp://${MQ_SHOVEL_VHOST:-}",
+						"src-delete-after": "never",
+						"src-protocol": "amqp091",
+						"src-queue": "verified",
+						"src-uri": "amqp://${MQ_SHOVEL_VHOST:-}"
+					},
+					"vhost": "${MQ_VHOST:-/}"
+				},
+				{
+					"component": "shovel",
+					"name": "cega_error",
+					"value": {
+						"ack-mode": "on-confirm",
+						"dest-exchange": "to_cega",
+						"dest-exchange-key": "files.error",
+						"dest-protocol": "amqp091",
+						"dest-uri": "amqp://${MQ_SHOVEL_VHOST:-}",
+						"src-delete-after": "never",
+						"src-protocol": "amqp091",
+						"src-queue": "error",
+						"src-uri": "amqp://${MQ_SHOVEL_VHOST:-}"
+					},
+					"vhost": "${MQ_VHOST:-/}"
+				},
+				{
 					"component": "federation-upstream",
+					"name": "CEGA-files",
 					"value": {
 						"ack-mode": "on-confirm",
 						"queue": "v1.files",
 						"trust-user-id": false,
 						"uri": "${CEGA_CONNECTION}"
-					}
+					},
+					"vhost": "${MQ_VHOST:-/}"
 				}
 			],
 			"policies": [
@@ -273,127 +359,17 @@ if [ -n "${CEGA_CONNECTION}" ]; then
 		}
 	EOF
 
-	if [ -n "${MQ_VHOST}" ]; then
-		MQ_VHOST="/${MQ_VHOST}"
-	fi
 	if [ -e "${MQ_SERVER_CERT}" ] && [ -e "${MQ_SERVER_KEY}" ]; then
 		cat >"/var/lib/rabbitmq/advanced.config" <<-EOF
 			[
 				{rabbit,  [
 					{tcp_listeners, []}
-				]},
+				]}
+			].
 		EOF
 	else
-		echo "[" >"/var/lib/rabbitmq/advanced.config"
+		echo "[]." >"/var/lib/rabbitmq/advanced.config"
 	fi
-	cat >>"/var/lib/rabbitmq/advanced.config" <<-EOF
-		{rabbitmq_shovel, [
-			{shovels, [
-				{to_cega, [
-					{source, [
-						{protocol, amqp091},
-						{uris,[ "amqp://${MQ_VHOST:-}" ]},
-						{declarations,  [
-							{'queue.declare', [{exclusive, true}]},
-							{'queue.bind', [{exchange, <<"to_cega">>}, {queue, <<>>}, {routing_key, <<"#">>}]}
-						]},
-						{queue, <<>>},
-						{prefetch_count, 10}
-					]},
-					{destination, [
-						{protocol, amqp091},
-						{uris, ["${CEGA_CONNECTION}"]},
-						{declarations, []},
-						{publish_properties, [{delivery_mode, 2}]},
-						{publish_fields, [{exchange, <<"localega.v1">>}]}
-					]},
-					{ack_mode, on_confirm},
-					{reconnect_delay, 5}
-				]},
-				{cega_completion, [
-					{source,  [
-						{protocol, amqp091},
-						{uris, ["amqp://${MQ_VHOST:-}"]},
-						{declarations, []},
-						{queue, <<"completed">>},
-						{prefetch_count, 10}
-					]},
-					{destination, [
-						{protocol, amqp091},
-						{uris, ["amqp://${MQ_VHOST:-}"]},
-						{declarations, []},
-						{publish_properties, [{delivery_mode, 2}]},
-						{publish_fields, [{exchange, <<"to_cega">>},
-						{routing_key, <<"files.completed">>}
-					]},
-					{ack_mode, on_confirm},
-					{reconnect_delay, 5}
-					]}
-				]},
-				{cega_error, [
-					{source,  [
-						{protocol, amqp091},
-						{uris, ["amqp://${MQ_VHOST:-}"]},
-						{declarations, []},
-						{queue, <<"error">>},
-						{prefetch_count, 10}
-					]},
-					{destination, [
-						{protocol, amqp091},
-						{uris, ["amqp://${MQ_VHOST:-}"]},
-						{declarations, []},
-						{publish_properties, [{delivery_mode, 2}]},
-						{publish_fields, [{exchange, <<"to_cega">>},
-						{routing_key, <<"files.error">>}
-					]},
-					{ack_mode, on_confirm},
-					{reconnect_delay, 5}
-					]}
-				]},
-				{cega_inbox, [
-					{source,  [
-						{protocol, amqp091},
-						{uris, ["amqp://${MQ_VHOST:-}"]},
-						{declarations, []},
-						{queue, <<"inbox">>},
-						{prefetch_count, 10}
-					]},
-					{destination, [
-						{protocol, amqp091},
-						{uris, ["amqp://${MQ_VHOST:-}"]},
-						{declarations, []},
-						{publish_properties, [{delivery_mode, 2}]},
-						{publish_fields, [{exchange, <<"to_cega">>},
-						{routing_key, <<"files.inbox">>}
-					]},
-					{ack_mode, on_confirm},
-					{reconnect_delay, 5}
-					]}
-				]},
-				{cega_verified, [
-					{source,  [
-						{protocol, amqp091},
-						{uris, ["amqp://${MQ_VHOST:-}"]},
-						{declarations, []},
-						{queue, <<"verified">>},
-						{prefetch_count, 10}
-					]},
-					{destination, [
-						{protocol, amqp091},
-						{uris, ["amqp://${MQ_VHOST:-}"]},
-						{declarations, []},
-						{publish_properties, [{delivery_mode, 2}]},
-						{publish_fields, [{exchange, <<"to_cega">>},
-						{routing_key, <<"files.verified">>}
-					]},
-					{ack_mode, on_confirm},
-					{reconnect_delay, 5}
-					]}
-				]}
-			]}
-		]}
-		].
-	EOF
 	chmod 600 "/var/lib/rabbitmq/advanced.config"
 else
 	cat >"/var/lib/rabbitmq/definitions.json" <<-EOF

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,6 +43,12 @@ else
 		echo 'No server certificates found, shuting down.' 1>&2 && exit 1
 	fi
 
+	if [ -e "${MQ_SERVER_CERT}" ] && [ -e "${MQ_SERVER_KEY}" ]; then
+		cat >>"/var/lib/rabbitmq/rabbitmq.conf" <<-EOF
+			listeners.tcp  = none
+		EOF
+	fi
+
 	chmod 600 "/var/lib/rabbitmq/rabbitmq.conf"
 fi
 
@@ -359,18 +365,6 @@ if [ -n "${CEGA_CONNECTION}" ]; then
 		}
 	EOF
 
-	if [ -e "${MQ_SERVER_CERT}" ] && [ -e "${MQ_SERVER_KEY}" ]; then
-		cat >"/var/lib/rabbitmq/advanced.config" <<-EOF
-			[
-				{rabbit,  [
-					{tcp_listeners, []}
-				]}
-			].
-		EOF
-	else
-		echo "[]." >"/var/lib/rabbitmq/advanced.config"
-	fi
-	chmod 600 "/var/lib/rabbitmq/advanced.config"
 else
 	cat >"/var/lib/rabbitmq/definitions.json" <<-EOF
 		{


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
> As of RabbitMQ 3.8.6, definition import happens after plugin activation. This means that definitions related to plugins (e.g. dynamic Shovels, exchanges of a custom type, and so on) can be imported at boot time.

https://www.rabbitmq.com/definitions.html

This aims to create a uniform configuration that is only in JSON format.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. move advanced.config erlang settings to definitions .json 
2. load configurations at boot time

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
~could not figure out if moving this is possible.~
```
[
    {rabbit,  [
        {tcp_listeners, []}
    ]}
].
```
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
