### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -561,5 +561,6 @@ else
 fi
 
 chmod 600 "/var/lib/rabbitmq/definitions.json"
+chmod g-rw "/var/lib/rabbitmq/.erlang.cookie"
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -561,6 +561,10 @@ else
 fi
 
 chmod 600 "/var/lib/rabbitmq/definitions.json"
-chmod g-rw "/var/lib/rabbitmq/.erlang.cookie"
+
+cookie_file="/var/lib/rabbitmq/.erlang.cookie"
+if [ -f "$cookie_file" ]; then
+    chmod g-rw "$cookie_file"
+fi
 
 exec "$@"


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Hello, 
I introduced one change in `entrypoint.sh`, that being changing permission on rabbitMQ cookie. When the broker starts for the first time, the cookie naturally does not exist yet and permissions are fixed in init container of the deployment. The change will not cause the failure of the skript in case of the cookie's nonexistence.

On the other side, If rabbitMQ deployment is restarted (e.g. due to cluster failure) rabbitMQ cookie has incorrect permissions after restart ( `rw-rw----` instead of `rw-------`). Since init containers are not performed on such occasions (e.g. restart of the Pod due to node failure), it is necessary to change the permissiond. This is solved by chmod in main container before starting rabbitMQ.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) added `chmod g-rw "/var/lib/rabbitmq/.erlang.cookie"` to `entrypoint.sh`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
